### PR TITLE
model/view: Timer triggers the view to get updates from the model

### DIFF
--- a/pyside/examples/modelview/tableView_2.py
+++ b/pyside/examples/modelview/tableView_2.py
@@ -1,0 +1,56 @@
+# http://doc.qt.io/qt-4.8/modelview.html
+# http://doc.qt.io/qt-4.8/modelview.html#2-3-a-clock-inside-a-table-cell
+
+from PySide import QtGui
+from PySide import QtCore
+
+Qt = QtCore.Qt
+
+
+class MyModel(QtCore.QAbstractTableModel):
+    def __init__(self, parent):
+        super(MyModel, self).__init__(parent)
+        self.topLeftCellIndex = self.createIndex(0, 0)
+        self.timer = QtCore.QTimer(self)
+        self.timer.setInterval(1000)
+        self.timer.timeout.connect(self.timerHit)
+        self.timer.start()
+    
+    def timerHit(self):
+        # emit a signal to make the view reread identified data
+        # When the model is attached to the view, the dataChanged signal
+        # is connected to a slot in the view!!
+        self.dataChanged.emit(self.topLeftCellIndex, self.topLeftCellIndex)
+    
+    def rowCount(self, modelIndex):
+        return 2
+    
+    def columnCount(self, modelIndex):
+        return 3
+    
+    def data(self, modelIndex, role=Qt.ItemDataRole.DisplayRole):
+        row = modelIndex.row()
+        column = modelIndex.column()
+        
+        if role == Qt.ItemDataRole.DisplayRole:
+            return QtCore.QTime.currentTime().toString()
+        elif role == Qt.ItemDataRole.FontRole:
+            if modelIndex == self.timerIndex:
+                boldFont = QtGui.QFont()
+                boldFont.setBold(True)
+                return boldFont
+        elif role == Qt.ItemDataRole.TextAlignmentRole:
+            return Qt.AlignVCenter
+        return ""
+
+
+tableView = QtGui.QTableView()
+
+tableView.show()
+
+myModel = MyModel(None)
+
+tableView.setModel(myModel)
+
+# Implicit signal/slot connections
+# The model's dataChanged signal is connected to a slot in the view!


### PR DESCRIPTION
http://doc.qt.io/qt-4.8/modelview.html#2-3-a-clock-inside-a-table-cell

We ask the view to read the data in the top left cell again by emitting the dataChanged() signal. Note that we did not explicitly connect the dataChanged() signal to the view. This happened automatically when we called setModel().